### PR TITLE
StructureSpawn.createCreep is deprecated and will be removed soon

### DIFF
--- a/prototype.spawn.js
+++ b/prototype.spawn.js
@@ -72,7 +72,8 @@ StructureSpawn.prototype.spawnCreepsIfNecessary =
                     }
                 }
                 // if no claim order was found, check other roles
-                else if (numberOfCreeps[role] < this.memory.minCreeps[role]) {
+                else if (this.memory.hasOwnProperty(this.memory.minCreeps) && this.memory.hasOwnProperty(this.memory.minCreeps[role])
+                         && numberOfCreeps[role] < this.memory.minCreeps[role]) {
                     if (role == 'lorry') {
                         name = this.createLorry(150);
                     }
@@ -130,7 +131,7 @@ StructureSpawn.prototype.createCustomCreep =
         }
 
         // create creep with the created body and the given role
-        return this.createCreep(body, undefined, { role: roleName, working: false });
+        return this.spawnCreep(body, roleName + '_' + Game.time, { memory: { role: roleName, working: false }});
     };
 
 // create a new function for StructureSpawn
@@ -156,26 +157,27 @@ StructureSpawn.prototype.createLongDistanceHarvester =
         }
 
         // create creep with the created body
-        return this.createCreep(body, undefined, {
+        return this.spawnCreep(body, roleName + '_' + Game.time, { memory: {
             role: 'longDistanceHarvester',
             home: home,
             target: target,
             sourceIndex: sourceIndex,
             working: false
-        });
+        }});
     };
 
 // create a new function for StructureSpawn
 StructureSpawn.prototype.createClaimer =
     function (target) {
-        return this.createCreep([CLAIM, MOVE], undefined, { role: 'claimer', target: target });
+        return this.spawnCreep([CLAIM, MOVE], 'claimer_' + Game.time, {memory: { role: 'claimer', target: target }});
     };
 
 // create a new function for StructureSpawn
 StructureSpawn.prototype.createMiner =
     function (sourceId) {
-        return this.createCreep([WORK, WORK, WORK, WORK, WORK, MOVE], undefined,
-                                { role: 'miner', sourceId: sourceId });
+        //return this.spawnCreep([CLAIM, MOVE], 'claimer_' + Game.time, {memory: { role: 'claimer', target: target }});
+        return this.spawnCreep([WORK, WORK, WORK, WORK, WORK, MOVE], 'miner_' + Game.time,
+                                {memory: { role: 'miner', sourceId: sourceId }});
     };
 
 // create a new function for StructureSpawn
@@ -194,5 +196,5 @@ StructureSpawn.prototype.createLorry =
         }
 
         // create creep with the created body and the role 'lorry'
-        return this.createCreep(body, undefined, { role: 'lorry', working: false });
+        return this.spawnCreep(body, 'lorry_' + Game.time, {memory: { role: 'lorry', working: false }});
     };


### PR DESCRIPTION
According to the documentation, `StructureSpawn.createCreep` is deprecated and will be removed soon. To ensure this is working in the future, I changed it as recommended. Sadly the new function, `StructureSpawn.spawnCreep`, does not support auto-naming, thus I had to set the name (role + game time). 

The change in line 75 is not related to that, but it's breaking the spawn logic, so I fixed that as well. In case the property `minCreep` is not set, trying to access it will thrown an exception. I guess you had the property preset before your refactoring prior to episode 14 of your YouTube series.

**P.S.** Thank you for your hard work with the videos and the code. Even 3 years later it's still pretty helpful 😄